### PR TITLE
fix: typo in _Boruta fit method

### DIFF
--- a/shaphypetune/_classes.py
+++ b/shaphypetune/_classes.py
@@ -508,7 +508,7 @@ class _Boruta(_BoostSelector):
                 break
 
             if self.verbose > 1:
-                print('Iterantion: {} / {}'.format(i + 1, self.max_iter))
+                print('Iteration: {} / {}'.format(i + 1, self.max_iter))
 
             self._random_state = np.random.RandomState(i + 1000)
 


### PR DESCRIPTION
Note that Github automatically added a newline at the end of the file.