### PR TITLE
update hyperopt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+Pipfile*
 
 # Spyder project settings
 .spyderproject

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ INSTALL_REQUIRES = [
     'scipy',
     'scikit-learn>=0.24.1',
     'shap>=0.39.0',
-    'hyperopt==0.2.5'
+    'hyperopt>=0.2.7'
 ]
 
 setup(name=PACKAGE_NAME,

--- a/shaphypetune/_classes.py
+++ b/shaphypetune/_classes.py
@@ -182,7 +182,7 @@ class _BoostSearch(BaseEstimator):
                     ),
                     space=self._param_combi, algo=tpe.suggest,
                     max_evals=self.n_iter, trials=trials,
-                    rstate=np.random.RandomState(self.sampling_seed),
+                    rstate=np.random.default_rng(self.sampling_seed),
                     show_progressbar=False, verbose=0
                 )
                 all_results = trials.results
@@ -536,7 +536,7 @@ class _Boruta(_BoostSelector):
             if self.verbose > 1:
                 print('Iteration: {} / {}'.format(i + 1, self.max_iter))
 
-            self._random_state = np.random.RandomState(i + 1000)
+            self._random_state = np.random.default_rng(i + 1000)
 
             # add shadow attributes, shuffle and train estimator
             self.support_ = dec_reg >= 0


### PR DESCRIPTION
The np.random.RandomState function was deprecated, and this was causing some issues with Hyperopt.

To fix this, I've 
* updated the hyperopt version in the setup.py file; 
* swapped out `np.random.RandomState` with `np.random.default_rng` in `_classes.py`

Tested locally with development installation and happy to report that the updated shaphypetune now works well with its hyperopt functionality. :)